### PR TITLE
Fix mismatched script calls in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "create-s3": ". ./scripts/create-s3-bucket.sh",
     "deploy": "node ./node_modules/dpl/dpl.js",
     "create-api": ". ./scripts/create-api.sh",
-    "deploy-app": "npm run deploy-lambda && npm run create-api",
+    "deploy-app": "npm run deploy && npm run create-api",
     "test": "node ./node_modules/.bin/mocha ./test/**/*.js",
     "coverage": "node_modules/.bin/istanbul cover node_modules/.bin/_mocha ./test/**/*.js --report lcov -- -R spec"
   },


### PR DESCRIPTION
The `deploy-app` script was calling through to a script named `deploy-lambda` which did not exist. Assume this should refer to `deploy` instead.
