### PR TITLE
Improvements to environment variable instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ The GraphQL IDE and UI live here: https://github.com/nikhilaravi/serverless-grap
 
 Add the following environment variables to a .env file
 ```sh
-AWS_ACCESS_KEY_ID='your_id_here'
-AWS_SECRET_ACCESS_KEY='your_id_here'
-AWS_REGION='region' (e.g. 'eu-west-1')
-API_KEY='api key'
+AWS_ACCESS_KEY_ID=[your_key_here]
+AWS_SECRET_ACCESS_KEY=[your_secret_here]
+AWS_REGION=[aws_region] (e.g. 'eu-west-1')
+API_KEY=[lastfm_api_key]
 ```
 
 ## Start building!

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The GraphQL IDE and UI live here: https://github.com/nikhilaravi/serverless-grap
 
 Add the following environment variables to a .env file
 ```sh
+AWS_ACCOUNT_ID=[your_account_id_here]
 AWS_ACCESS_KEY_ID=[your_key_here]
 AWS_SECRET_ACCESS_KEY=[your_secret_here]
 AWS_REGION=[aws_region] (e.g. 'eu-west-1')


### PR DESCRIPTION
I hit a few bumps trying to get these set up correctly when setting up for the first time, these changes hopefully make the process clearer.
- Add `AWS_ACCOUNT_ID` environment variable to .env as it is needed by the `create-api` script
- Attempt to make it clear that values of env vars should _not_ be wrapped in single quotes (which I did the first time, and made things fail as a result)
